### PR TITLE
fix(mantine): make Mermaid controls keyboard accessible

### DIFF
--- a/packages/mantine/src/MantineAIMarkdown.test.tsx
+++ b/packages/mantine/src/MantineAIMarkdown.test.tsx
@@ -86,8 +86,12 @@ describe('MantineAIMarkdown smoke', () => {
     expect(html).toContain('data-scheme="light"');
   });
 
-  test('mermaid code fence renders without crashing under SSR', () => {
+  test('mermaid code fence exposes keyboard-accessible controls under SSR', () => {
     const html = renderMarkdown(<MantineAIMarkdown content={'```mermaid\ngraph TD;\nA-->B;\n```'} />);
-    expect(html.length).toBeGreaterThan(0);
+    expect(html).toContain('aria-label="Show Mermaid code"');
+    expect(html).toContain('aria-label="Copy Mermaid code"');
+    expect(html).toMatch(
+      /<pre[^>]+role="button"[^>]+tabindex="0"[^>]+aria-label="Open Mermaid diagram in a new window"/
+    );
   });
 });

--- a/packages/mantine/src/components/customized/MermaidCode/index.tsx
+++ b/packages/mantine/src/components/customized/MermaidCode/index.tsx
@@ -362,6 +362,7 @@ const MantineAIMMermaidCode = memo((props: { code: string }) => {
                 size={28}
                 className="action-icon"
                 variant="transparent"
+                aria-label="Show Mermaid code"
                 onClick={() => {
                   setShowOriginalCode(true);
                 }}
@@ -374,7 +375,13 @@ const MantineAIMMermaidCode = memo((props: { code: string }) => {
             <CopyButton value={props.code}>
               {({ copied, copy }) => (
                 <Tooltip label={copied ? 'Copied' : 'Copy'} withArrow position="right">
-                  <ActionIcon variant="transparent" size={28} className="action-icon" onClick={copy}>
+                  <ActionIcon
+                    variant="transparent"
+                    size={28}
+                    className="action-icon"
+                    aria-label={copied ? 'Mermaid code copied' : 'Copy Mermaid code'}
+                    onClick={copy}
+                  >
                     {copied ? (
                       <span className="icon-origin-[lucide--check] text-[18px]"></span>
                     ) : (
@@ -400,7 +407,20 @@ const MantineAIMMermaidCode = memo((props: { code: string }) => {
             </CopyButton>
           </Flex>
         </div>
-        <pre ref={ref} style={PRE_STYLE} onClick={viewSvgInNewWindow} />
+        <pre
+          ref={ref}
+          style={PRE_STYLE}
+          role="button"
+          tabIndex={0}
+          aria-label="Open Mermaid diagram in a new window"
+          onClick={viewSvgInNewWindow}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              viewSvgInNewWindow();
+            }
+          }}
+        />
       </div>
     </>
   );


### PR DESCRIPTION
## Summary

Make the Mantine Mermaid diagram controls usable without a pointer. The rendered diagram can now be opened with Enter or Space, and the icon-only source/copy controls expose explicit accessible names.

## Type

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds capability)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] Documentation only
- [ ] Internal / chore (build, CI, refactor with no behavior change)

## Test plan

- `pnpm --filter @ai-react-markdown/mantine test` — 13 tests passed, including the new SSR accessibility assertions.
- `pnpm --filter @ai-react-markdown/mantine typecheck` — passed.
- `pnpm typecheck` — passed.
- `pnpm lint` — passed.
- Prettier check on both changed files — passed.
- `pnpm vitest run` — 51 unit-test files / 997 tests passed; the Storybook browser project could not start locally because the Playwright Chromium binary was not installed.

For manual verification after a Mermaid diagram renders:

1. Tab to the diagram and press Enter or Space; the SVG opens in a new window.
2. Inspect the two icon-only buttons with an accessibility tree; they are named “Show Mermaid code” and “Copy Mermaid code”.

## Related issues / discussions

No related issue; this was found while reviewing the Mantine Mermaid interaction path.

## Checklist

- [x] I've read [`CONTRIBUTING.md`](../CONTRIBUTING.md)
- [x] Tests pass locally (`pnpm --filter @ai-react-markdown/core test`)
- [x] Typecheck passes (`pnpm --filter @ai-react-markdown/core typecheck`)
- [x] Lint passes (`pnpm lint`)
- [ ] Format check passes (`pnpm format:check`)
- [x] Docs updated if the public API or behavior changed (`README.md` / `docs/` / JSDoc) — no public API or documentation change required
- [x] For breaking changes: migration path documented in the PR description — not applicable

The full-repository format check reports existing CRLF differences across the Windows checkout; `prettier --check` passes for both files changed by this PR.
