### PR TITLE
chore: move the toolchain to pnpm 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,16 +34,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-        # Version is pinned via `packageManager` in package.json — pnpm/action-setup
-        # picks it up automatically.
-
-      - name: Setup Node ${{ matrix.node }}
-        uses: actions/setup-node@v7
+      # pnpm/setup (not pnpm/action-setup, which stops at pnpm 10) installs
+      # pnpm and the Node runtime in one step. The pnpm version comes from
+      # `packageManager` in package.json; `install: false` keeps the explicit
+      # frozen-lockfile step below, so a lockfile drift fails loudly here
+      # rather than inside the action.
+      - name: Setup pnpm + Node ${{ matrix.node }}
+        uses: pnpm/setup@v2
         with:
-          node-version: ${{ matrix.node }}
-          cache: pnpm
+          runtime: node@${{ matrix.node }}
+          cache: true
+          install: false
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,9 @@ name: Release
 # Auth is npm "trusted publishing" (OIDC): this repo+workflow is registered
 # as a trusted publisher for both packages on npmjs.com, so no token secret
 # exists at all — npm mints a short-lived credential from the id-token
-# permission below, and provenance is attached automatically. The publish
-# step runs under pnpm 11 (via npx) because native OIDC support landed in
-# pnpm 11.1.3; the rest of the workflow stays on the workspace-pinned pnpm.
+# permission below, and provenance is attached automatically. pnpm's own
+# native OIDC support landed in 11.1.3, below the version pinned here, so the
+# workflow-wide pnpm publishes directly — no npx side-channel.
 
 on:
   push:
@@ -48,17 +48,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-
-      # No registry-url: with trusted publishing there is no auth token, and
-      # registry-url would write an .npmrc with an unresolved ${NODE_AUTH_TOKEN}
-      # placeholder that interferes with the OIDC flow.
-      - name: Setup Node
-        uses: actions/setup-node@v7
+      # pnpm/setup (not pnpm/action-setup, which stops at pnpm 10) installs
+      # pnpm and Node in one step, taking the pnpm version from
+      # `packageManager`. No registry-url equivalent is configured anywhere:
+      # with trusted publishing there is no auth token, and writing an .npmrc
+      # with an unresolved ${NODE_AUTH_TOKEN} placeholder would interfere with
+      # the OIDC flow.
+      - name: Setup pnpm + Node
+        uses: pnpm/setup@v2
         with:
-          node-version: '22'
-          cache: pnpm
+          runtime: node@22
+          cache: true
+          install: false
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -131,11 +132,11 @@ jobs:
         run: |
           case "$GITHUB_REF_NAME" in
             v*)
-              npx -y pnpm@^11.1.3 publish -r --access public --no-git-checks
+              pnpm publish -r --access public --no-git-checks
               ;;
             *-v*)
               PKG_DIR="${GITHUB_REF_NAME%-v*}"
-              npx -y pnpm@^11.1.3 publish --filter "./packages/${PKG_DIR}" --access public --no-git-checks
+              pnpm publish --filter "./packages/${PKG_DIR}" --access public --no-git-checks
               ;;
           esac
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,9 @@ pnpm build
 You'll need:
 
 - Node ≥ 20 (LTS recommended)
-- pnpm 10.x (this repo pins via `packageManager` field — Corepack will fetch the right version)
+- pnpm 11.x (this repo pins the exact version via the `packageManager` field — Corepack, or pnpm itself, will fetch it)
+
+> pnpm settings live in `pnpm-workspace.yaml`, not in a `pnpm` field in `package.json` — pnpm 11 ignores that field. `pnpm check:overrides` fails the build if one reappears, or if the lockfile no longer matches the declared overrides.
 
 ## Daily workflow
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "bugs": {
     "url": "https://github.com/AIEPhoenix/ai-react-markdown/issues"
   },
-  "packageManager": "pnpm@10.28.1",
+  "packageManager": "pnpm@11.20.0",
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.5",
     "@chromatic-com/storybook": "^5.2.1",
@@ -72,18 +72,5 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.58.2",
     "vitest": "^4.1.10"
-  },
-  "pnpm": {
-    "overrides": {
-      "dompurify": "^3.4.0",
-      "uuid": "^11.1.1",
-      "qs@<6.15.2": ">=6.15.2",
-      "fast-uri@>=3.0.0 <3.1.5": ">=3.1.5 <4",
-      "brace-expansion@>=3.0.0 <5.0.7": ">=5.0.7",
-      "esbuild@<0.28.1": ">=0.28.1",
-      "typescript@>=7": "^6.0.3",
-      "react-doctor": "0.8.1",
-      "react-grab": "0.1.48"
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,27 +1,32 @@
 packages:
   - 'packages/*'
 
-# ⚠️ KEEP IN SYNC with the `pnpm.overrides` block in the root package.json.
+# Dependency install scripts, allowed one by one (pnpm 11 replaced
+# onlyBuiltDependencies / neverBuiltDependencies / ignoredBuiltDependencies
+# with this single map). Both entries are `false` because neither script is
+# needed: modern esbuild ships per-platform binaries as optionalDependencies
+# rather than fetching them in a postinstall, and @parcel/watcher — an
+# optional transitive of sass — ships prebuilds too. This repo never had a
+# built-dependencies allowlist under pnpm 10 either, so these scripts have
+# always been skipped, across every green build to date. Flip one to `true`
+# only with evidence that its absence broke something.
+allowBuilds:
+  '@parcel/watcher': false
+  esbuild: false
+
+# This file is the ONLY place pnpm reads settings from (11.x behavior). The
+# root package.json used to carry a `pnpm.overrides` block for pnpm 10; it is
+# gone, and `pnpm check:overrides` fails the build if one reappears, because
+# pnpm 11 would ignore it without applying anything.
 #
-# Which of the two locations pnpm reads depends on its major version, and it
-# reads exactly ONE of them — there is no merge, and no fallback:
-#
-#   pnpm 10 (what `packageManager` pins today): reads package.json#pnpm,
-#           and ignores this block entirely. Silently — no warning.
-#   pnpm 11: reads this block, and ignores package.json#pnpm (with a warning).
-#
-# So a rule that lives in only one file is a rule that is off half the time.
-# Both copies below carry the same content, verified against pnpm 10.28.1 and
-# pnpm 11.20.0. When this repo moves to pnpm 11, delete the package.json block
-# and this warning — until then, every edit goes in both places.
-#
-# Two rules that were in this file before and are deliberately NOT here now:
+# Two rules that lived here before the pnpm 11 move and are deliberately NOT
+# here now (this block had never actually taken effect under pnpm 10, so they
+# had gone unexercised):
 #
 #   picomatch: ^4.0.4  — no advisory has ever been filed against picomatch in
 #     this repo, and micromatch@4.0.8 / anymatch@3.1.3 declare `^2.3.1` /
 #     `^2.0.4`. Forcing 4.x on them crosses two majors against their own
-#     declared range, buying nothing. (This block never took effect, so the
-#     rule had never actually been exercised.)
+#     declared range, buying nothing.
 #   typescript: ^6.0.3 — the unscoped form also rewrites packages that pin an
 #     exact older TS (react-doctor pins 5.6.1-rc). Narrowed to `typescript@>=7`
 #     below, which is what the intent was: keep TS 7 out, touch nothing else.

--- a/scripts/assert-overrides-in-sync.mjs
+++ b/scripts/assert-overrides-in-sync.mjs
@@ -1,17 +1,18 @@
 /* global process, console */
 
 /**
- * pnpm reads dependency overrides from exactly ONE of two places, and which
- * one depends on its major version:
+ * Asserts that the `overrides:` block in pnpm-workspace.yaml matches what the
+ * lockfile records as actually applied. A disagreement means the lockfile is
+ * stale — someone edited the overrides without re-running `pnpm install` — and
+ * the rules people believe are in force are not the rules that resolved the
+ * tree.
  *
- *   pnpm 10  →  package.json  #pnpm.overrides   (this block is ignored, silently)
- *   pnpm 11  →  pnpm-workspace.yaml  overrides: (package.json is ignored, with a warning)
- *
- * There is no merge and no fallback. This repo therefore keeps both copies,
- * identical, so the rules hold across the version boundary — and this script
- * is what stops them from drifting apart. It also checks the lockfile, which
- * records what the installed pnpm actually applied: if that disagrees, the
- * lockfile is stale and someone needs to re-run `pnpm install`.
+ * Why a script exists for this at all: overrides used to live in
+ * package.json#pnpm.overrides, which pnpm 10 read and pnpm 11 ignores. During
+ * the 10→11 transition this repo carried both copies and this script kept the
+ * three in agreement. pnpm is pinned to 11 now, package.json#pnpm is gone, and
+ * only the workspace-file-vs-lockfile check remains — the part that catches a
+ * stale lockfile, which is version-independent.
  *
  * Runs first in `pnpm preflight`. Exit code 1 on any mismatch.
  */
@@ -47,53 +48,42 @@ function readYamlOverrides(file) {
   return out;
 }
 
-function readJsonOverrides(file) {
-  const pkg = JSON.parse(readFileSync(join(root, file), 'utf8'));
-  const overrides = pkg.pnpm?.overrides;
-  if (!overrides) throw new Error(`${file}: no \`pnpm.overrides\` block found`);
-  return overrides;
-}
-
 /** Order is irrelevant to pnpm, so compare as sorted key=value pairs. */
 const normalize = (o) =>
   Object.entries(o)
     .map(([k, v]) => `${k} = ${v}`)
     .sort();
 
-const sources = {
-  'package.json (pnpm 10 reads this)': readJsonOverrides('package.json'),
-  'pnpm-workspace.yaml (pnpm 11 reads this)': readYamlOverrides('pnpm-workspace.yaml'),
-  'pnpm-lock.yaml (what was actually applied)': readYamlOverrides('pnpm-lock.yaml'),
-};
+const DECLARED = 'pnpm-workspace.yaml (the source of truth)';
+const APPLIED = 'pnpm-lock.yaml (what was actually applied)';
 
-const [reference, ...others] = Object.entries(sources);
-const failures = [];
+const declared = normalize(readYamlOverrides('pnpm-workspace.yaml'));
+const applied = normalize(readYamlOverrides('pnpm-lock.yaml'));
 
-for (const [name, overrides] of others) {
-  const a = normalize(reference[1]);
-  const b = normalize(overrides);
-  if (a.join('\n') === b.join('\n')) continue;
+// A stray `pnpm` field would be silently ignored by pnpm 11 — flag it rather
+// than let someone add rules there that never take effect.
+const strayPnpmField = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8')).pnpm;
 
-  const missing = a.filter((line) => !b.includes(line));
-  const extra = b.filter((line) => !a.includes(line));
-  failures.push(
-    [
-      `${name} disagrees with ${reference[0]}:`,
-      ...missing.map((l) => `    only in ${reference[0]}:  ${l}`),
-      ...extra.map((l) => `    only in ${name}:  ${l}`),
-    ].join('\n')
-  );
-}
-
-if (failures.length > 0) {
+if (declared.join('\n') !== applied.join('\n') || strayPnpmField) {
   console.error('\npnpm overrides are out of sync.\n');
-  console.error(failures.join('\n\n'));
-  console.error(
-    '\nEvery override must be written identically in package.json and' +
-      '\npnpm-workspace.yaml, then applied with `pnpm install`. See the comment' +
-      '\nat the top of pnpm-workspace.yaml for why both copies exist.\n'
-  );
+
+  if (strayPnpmField) {
+    console.error(
+      `package.json has a \`pnpm\` field (${Object.keys(strayPnpmField).join(', ')}).` +
+        '\npnpm 11 does not read it — move those settings into pnpm-workspace.yaml.\n'
+    );
+  }
+
+  const missing = declared.filter((line) => !applied.includes(line));
+  const extra = applied.filter((line) => !declared.includes(line));
+  if (missing.length > 0 || extra.length > 0) {
+    console.error(`${APPLIED} disagrees with ${DECLARED}:`);
+    for (const l of missing) console.error(`    only in ${DECLARED}:  ${l}`);
+    for (const l of extra) console.error(`    only in ${APPLIED}:  ${l}`);
+    console.error('\nThe lockfile is stale — run `pnpm install` to apply the declared overrides.\n');
+  }
+
   process.exit(1);
 }
 
-console.log(`pnpm overrides in sync across all three files (${normalize(reference[1]).length} rules).`);
+console.log(`pnpm overrides in sync (${declared.length} rules).`);


### PR DESCRIPTION
Locks the toolchain to `pnpm@11.20.0`.

This is a small diff because the hard part landed in `20c9e38`: the overrides
were already mirrored into `pnpm-workspace.yaml`, so dropping
`package.json#pnpm` — which pnpm 11 ignores — costs nothing.

## Why it is low risk

Re-resolving the entire tree under 11.20.0 produces a **byte-identical
lockfile**, `lockfileVersion: '9.0'` included. None of the nine documented
v10→v11 breaking changes apply: no `npm_config_*`, no `useNodeVersion`, no
built-dependency lists, no patches, no `auditConfig`, and no script names
colliding with the newly shadowing built-ins.

## The part that needed real work

CI could not just follow the `packageManager` field — `pnpm/action-setup`
stops at pnpm 10. Both workflows move to `pnpm/setup@v2`, which installs pnpm
and the Node runtime in one step and replaces `actions/setup-node`.
`install: false` keeps the explicit `--frozen-lockfile` step, so lockfile
drift still fails loudly in the same place as before. Release can now publish
with the workflow-wide pnpm instead of shelling out to `npx pnpm@^11.1.3` for
OIDC support.

**This is the only part that could not be verified locally — it is the reason
this is a PR rather than a push to main.**

## Two new behaviors, pinned deliberately

- **`allowBuilds`** replaces the old built-dependency lists. pnpm wrote
  placeholders for `@parcel/watcher` and `esbuild` on first install; both are
  `false`. This repo never had a built-dependency allowlist under pnpm 10
  either, so neither install script has ever run — across every green build to
  date. Modern esbuild ships per-platform binaries as `optionalDependencies`
  rather than fetching them in a postinstall.
- **`minimumReleaseAge`** is on by default (~32h observed) and verifies the
  lockfile on every install, CI included. It rejected one entry — an optional
  wasm32-wasi platform package pulled in by the dependency refresh in
  `1c3a835` — until that version aged past the window. No override was added
  and the policy was not relaxed: bypassing it locally only moves the failure
  to CI, and the timestamp makes the condition self-resolving.

Worth noting that this policy closes a real gap. The 7-day cooldown in
`dependabot.yml` only constrains PRs dependabot opens; a hand-run
`pnpm update` walks straight past it. pnpm 11 applies the check to every
install path.

## Guard update

`check:overrides` drops to a two-way check (workspace file vs lockfile,
catching a stale lockfile) and now also fails if a `pnpm` field reappears in
`package.json`, since pnpm 11 would ignore it silently.

## Verification (local, under 11.20.0)

- `pnpm preflight` — 1162 tests green
- storybook browser smokes — 50 tests green
- `pnpm install --frozen-lockfile` under the default supply-chain policy — clean