### PR TITLE
Fix soak impact classification for private Storybook workspaces

### DIFF
--- a/docs/soak-coverage.md
+++ b/docs/soak-coverage.md
@@ -47,6 +47,10 @@ PR and main-branch CI include an **Assess engine soak impact** check and a depen
 
 Run `pnpm check:soak-impact` to compare the committed candidate with its nearest preceding train tag. Use `--base <commit-or-tag> --head <commit>` to inspect an explicit ancestor range. Engine and highlight runtime changes, runtime exports, engine tests and build configuration, relevant transitive lockfile dependencies, shared toolchain changes, and changes to the soak mechanism require verification. Comments and erased TypeScript types are ignored. Unresolvable dependency impact or a missing prior train tag requires soak; an invalid Git range fails the check.
 
+The six soak legs start Vitest in `packages/engine` and use that package's configuration. Root `vitest.config.ts` changes belong to the normal unit/Storybook gates and do not invalidate engine soak evidence. Changes to `packages/engine/vitest.config.ts`, engine build settings, or the actual soak runner still do.
+
+Workspace declarations are compared by effective inclusion of engine verification workspaces, using the historical lockfile's local dependency closure. Adding private app or tooling globs is harmless when those inputs stay included and installation settings are unchanged. Excluding engine inputs, changing overrides or install options, or failing to resolve the configuration requires soak. `corpus/documents` files are executable inputs read by engine differential verification, so changing them is not treated as a documentation-only edit. Changes to the impact classifier and evidence gate themselves remain mechanism changes; a fix to the classifier is not exempt from its own rule.
+
 Full campaigns run on developer equipment. After committing a clean candidate, run `SOAK_PROFILE=release scripts/soak/soak.sh <fresh-seed-base> <label>` with a fresh seed. The default six legs and 14 logical shards define 84 tasks; `WORKERS` changes concurrency without reducing the logical budget. Validate the resulting evidence against the release candidate with:
 
 ```sh

--- a/scripts/soak/impact.mjs
+++ b/scripts/soak/impact.mjs
@@ -18,6 +18,7 @@ const manifestInputs = (text) => {
     Object.fromEntries(
       [
         'dependencies',
+        'devDependencies',
         'optionalDependencies',
         'peerDependencies',
         'peerDependenciesMeta',
@@ -80,6 +81,37 @@ export function dependencyGraph(lockText) {
   }
   return canonical(result);
 }
+/** Workspace globs affect soak only when they stop including one of its local
+ * inputs. All other install/resolution options remain significant. Resolve the
+ * local dependency closure from each historical lockfile, never from node_modules.
+ * Corpus documents are read directly by engine verification outside that graph. */
+export function workspaceInputs(text, lockText) {
+  const config = parse(text);
+  if (!config || typeof config !== 'object' || Array.isArray(config)) throw new Error('Invalid workspace config');
+  const { packages = ['**'], ...options } = config;
+  if (!Array.isArray(packages) || !packages.every((pattern) => typeof pattern === 'string' && pattern.length > 0))
+    throw new Error('Invalid workspace patterns');
+  const graph = JSON.parse(dependencyGraph(lockText));
+  const inputs = [
+    ...new Set([
+      'packages/engine',
+      'packages/remark-mark-highlight',
+      'corpus',
+      ...Object.keys(graph)
+        .filter((key) => key.startsWith('workspace:'))
+        .map((key) => key.slice('workspace:'.length)),
+    ]),
+  ].sort();
+  const positive = packages.filter((pattern) => !pattern.startsWith('!'));
+  const negative = packages.filter((pattern) => pattern.startsWith('!')).map((pattern) => pattern.slice(1));
+  const included = inputs.map((directory) => [
+    directory,
+    positive.some((pattern) => path.posix.matchesGlob(directory, pattern)) &&
+      !negative.some((pattern) => path.posix.matchesGlob(directory, pattern)),
+  ]);
+  if (included.some(([, present]) => !present)) throw new Error('Engine verification workspace is excluded');
+  return canonical({ options, included });
+}
 export function classify(paths, before, after) {
   const reasons = [];
   for (const file of paths) {
@@ -92,6 +124,13 @@ export function classify(paths, before, after) {
           reasons.push(`${file}: engine/test/build dependency graph changed`);
       } catch {
         reasons.push(`${file}: dependency impact could not be resolved`);
+      }
+    } else if (file === 'pnpm-workspace.yaml') {
+      try {
+        if (workspaceInputs(a, before('pnpm-lock.yaml')) !== workspaceInputs(b, after('pnpm-lock.yaml')))
+          reasons.push(`${file}: engine workspace membership or installation settings changed`);
+      } catch {
+        reasons.push(`${file}: engine workspace impact could not be resolved`);
       }
     } else if (file === 'package.json') {
       const inputs = (text) => {
@@ -124,12 +163,15 @@ export function classify(paths, before, after) {
       if (/\.(md|txt)$|\/LICENSE$/.test(file)) continue;
       if (/\.[cm]?[jt]sx?$/.test(file) && a && b && executable(a) === executable(b)) continue;
       reasons.push(`${file}: engine/plugin implementation or verification changed`);
-    } else if (
-      /^scripts\/soak\/|^vitest.config.ts$|^pnpm-workspace\.yaml$|^tsconfig\.base\.json$|^patches\//.test(file)
-    ) {
+    } else if (/^corpus\/documents\//.test(file)) {
+      reasons.push(`${file}: engine differential verification input changed`);
+    } else if (/^scripts\/soak\/|^tsconfig\.base\.json$|^patches\//.test(file)) {
       if (!file.endsWith('.md')) reasons.push(`${file}: shared toolchain or soak mechanism changed`);
     }
   }
+  // Root vitest.config.ts hosts unit/Storybook projects for normal CI. The
+  // six soak legs start in packages/engine and load its own vitest.config.ts,
+  // already covered by the engine path rule. Do not couple evidence to UI setup.
   return { required: reasons.length > 0, reasons };
 }
 export function inspect(base, head = 'HEAD', cwd = process.cwd()) {

--- a/scripts/soak/impact.test.mjs
+++ b/scripts/soak/impact.test.mjs
@@ -131,12 +131,22 @@ test('Git evidence ranges allow adapter follow-ups but invalidate engine changes
     git('init');
     mkdirSync(join(dir, 'packages/engine/src'), { recursive: true });
     writeFileSync(join(dir, 'packages/engine/src/x.ts'), 'export const x = 1;');
+    writeFileSync(join(dir, 'pnpm-workspace.yaml'), workspace());
+    writeFileSync(join(dir, 'pnpm-lock.yaml'), lock());
     const tested = commit();
     assert.equal(inspect(undefined, tested, dir).required, true);
     git('tag', 'v1.0.0');
     writeFileSync(join(dir, 'README.md'), 'Reader documentation');
     const docs = commit();
     assert.equal(inspect(undefined, docs, dir).required, false);
+    writeFileSync(
+      join(dir, 'pnpm-workspace.yaml'),
+      workspace(['packages/*', 'corpus', 'apps/storybook-*', 'tooling/storybook-kit'])
+    );
+    writeFileSync(join(dir, 'vitest.config.ts'), 'export default { browserCatalogs: ["react", "vue"] };');
+    const catalogs = commit();
+    assert.equal(inspect(tested, catalogs, dir).required, false);
+    assert.equal(inspect(undefined, catalogs, dir).required, false);
     writeFileSync(join(dir, 'packages/engine/src/x.ts'), 'export const x = 2;');
     const changed = commit();
     assert.equal(inspect(tested, changed, dir).required, true);
@@ -166,4 +176,86 @@ test('release validation rejects custom baselines before evidence inspection', a
   );
   assert.notEqual(result.status, 0);
   assert.match(result.stderr, /always checks HEAD against the preceding train tag/);
+});
+
+const workspace = (packages = ['packages/*', 'corpus'], options = {}) => JSON.stringify({ packages, ...options });
+const workspaceCheck = (a, b, lockfile = lock()) =>
+  classify(
+    ['pnpm-workspace.yaml'],
+    (file) => (file === 'pnpm-lock.yaml' ? lockfile : a),
+    (file) => (file === 'pnpm-lock.yaml' ? lockfile : b)
+  );
+
+test('private app/tooling workspace additions and equivalent globs do not invalidate engine evidence', () => {
+  const base = workspace();
+  assert.equal(
+    workspaceCheck(base, workspace(['packages/*', 'corpus', 'apps/storybook-*', 'tooling/storybook-kit'])).required,
+    false
+  );
+  assert.equal(
+    workspaceCheck(base, workspace(['corpus', 'packages/{engine,remark-mark-highlight}', 'packages/vue'])).required,
+    false
+  );
+  assert.equal(workspaceCheck(base, workspace(['packages/*', 'corpus', '!apps/**'])).required, false);
+  assert.equal(workspaceCheck(base, base + '\n# Reader comment\n').required, false);
+});
+
+test('workspace exclusions, missing dependency context and install policy changes remain fail closed', () => {
+  const base = workspace();
+  for (const packages of [
+    [],
+    ['packages/*'],
+    ['corpus', 'packages/vue'],
+    ['packages/*', 'corpus', '!packages/engine'],
+    ['packages/*', 'corpus', '!packages/remark-mark-highlight'],
+  ])
+    assert.equal(workspaceCheck(base, workspace(packages)).required, true, JSON.stringify(packages));
+  for (const options of [
+    { overrides: { x: '2' } },
+    { allowBuilds: { esbuild: true } },
+    { nodeLinker: 'hoisted' },
+    { catalog: { x: '2' } },
+  ])
+    assert.equal(workspaceCheck(base, workspace(undefined, options)).required, true);
+  for (const invalid of ['', 'null', 'packages: [', 'packages: invalid', 'packages: [1]'])
+    assert.equal(workspaceCheck(base, invalid).required, true);
+  assert.equal(workspaceCheck(base, workspace(['packages/*', 'corpus', 'apps/*']), '{}').required, true);
+});
+
+test('workspace membership follows linked engine verification dependencies', () => {
+  const data = JSON.parse(lock());
+  data.importers['packages/engine'].devDependencies = { generator: { version: 'link:../../tooling/generator' } };
+  data.importers['tooling/generator'] = {};
+  const lockfile = JSON.stringify(data);
+  const base = workspace(['packages/*', 'corpus', 'tooling/*']);
+  assert.equal(
+    workspaceCheck(base, workspace(['packages/*', 'corpus', 'tooling/*', 'apps/*']), lockfile).required,
+    false
+  );
+  assert.equal(workspaceCheck(base, workspace(), lockfile).required, true);
+});
+
+test('root browser configuration is separate from actual engine verification inputs', () => {
+  assert.equal(check('vitest.config.ts', 'React catalog', 'React and Vue catalogs'), false);
+  assert.equal(check('apps/storybook-vue/.storybook/main.ts', 'a', 'b'), false);
+  assert.equal(check('tooling/storybook-kit/common/corpus.ts', 'a', 'b'), false);
+  for (const file of [
+    'packages/engine/vitest.config.ts',
+    'packages/engine/vitest.evidence.config.ts',
+    'tsconfig.base.json',
+    'scripts/soak/soak-runner.mjs',
+    'scripts/soak/impact.mjs',
+    'corpus/documents/math.md',
+    'corpus/documents/new-case.md',
+  ])
+    assert.equal(check(file, 'const a=1;', 'const a=2;'), true, file);
+  assert.equal(check('corpus/documents/math.md', 'input', ''), true);
+  assert.equal(
+    check(
+      'packages/engine/package.json',
+      '{"devDependencies":{"fast-check":"1"}}',
+      '{"devDependencies":{"fast-check":"2"}}'
+    ),
+    true
+  );
 });


### PR DESCRIPTION
Adding private Storybook workspaces and splitting browser projects incorrectly invalidated engine soak evidence. The soak runner actually starts Vitest inside packages/engine, using that package's configuration.

Remove the root Vitest configuration trigger and compare workspace declarations by effective inclusion of engine verification workspaces, derived from historical lockfiles. Preserve conservative handling of installation settings, relevant dependency changes and unresolved configuration. Also cover corpus documents read by engine differential tests and engine/plugin development dependency manifests.

Regression coverage verifies private workspace additions, equivalent globs, exclusions, linked engine tooling, invalid settings, actual engine configuration changes and cumulative Git evidence ranges. Classifier and evidence-mechanism changes still require verification; this PR does not exempt itself or bypass the release approval gate.

Validation:
- 34 soak-control tests and release-control tests passed; lint and formatting passed.
- Reassessing v3.0.0-beta.2 through the Storybook merge f58b2d3 with the corrected classifier returns required=false with no reasons.
- This repair itself remains required because it changes the soak classifier and its tests. That is distinct from the corrected Storybook false positive.
