### PR TITLE
Embed Storybook examples and publish the organization root website

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_call:
   workflow_dispatch:
 
 permissions:
@@ -19,6 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          repository: ai-markdown/ai-markdown
+          ref: ${{ github.repository == 'ai-markdown/ai-markdown' && github.ref || 'main' }}
       - uses: pnpm/setup@v2
         with:
           runtime: node@22.23.2
@@ -45,6 +49,9 @@ jobs:
       - run: pnpm assemble:pages
       - name: Check assembled documentation and example links
         run: DOCS_DIST=_site pnpm test:docs
+      - name: Record published source
+        run: |
+          git rev-parse HEAD > _site/source-commit.txt
       - uses: actions/upload-pages-artifact@v3
         with:
           path: _site

--- a/apps/docs/content/examples.md
+++ b/apps/docs/content/examples.md
@@ -1,5 +1,7 @@
 # Interactive examples
 
+[Open the embedded examples workspace](examples:).
+
 Explore live rendering behavior in the Storybook catalogs. React and Vue share capability chapter names, while Mantine extends the React catalog.
 
 | Catalog                                                                      | Explore                                                          |

--- a/apps/docs/scripts/check-links.mjs
+++ b/apps/docs/scripts/check-links.mjs
@@ -44,6 +44,7 @@ const failures = [];
 for (const [route, sidebar] of [
   ['', false],
   ['docs', true],
+  ['examples', false],
 ]) {
   const document = documents.get(resolve(dist, route, 'index.html'));
   assert(document, `Missing ${route || 'homepage'}`);
@@ -58,6 +59,16 @@ for (const [route, sidebar] of [
   for (const theme of ['auto', 'light', 'dark']) assert(options.some((option) => option.properties.value === theme));
   assert(options.some((option) => option.children.some((child) => child.type === 'text' && child.value === 'English')));
   assert(document.links.includes(`${base}docs/`), 'Docs navigation must enter the documentation area');
+  assert(document.links.includes(`${base}examples/`), 'Examples navigation must enter the embedded workspace');
+  if (route === 'examples') {
+    let embedded = false;
+    visit(document.tree, 'element', (node) => {
+      if (node.tagName === 'iframe' && node.properties.id === 'examples-catalog') {
+        embedded = Boolean(node.properties.src && node.properties.title);
+      }
+    });
+    assert(embedded, 'Examples must include an accessible Storybook iframe');
+  }
 }
 for (const { slug } of pages())
   if (!documents.has(resolve(dist, slug, 'index.html'))) failures.push(`Missing page: ${slug || '/'}`);
@@ -67,6 +78,8 @@ for (const [file, { links }] of documents) {
     .replace(/index\.html$/, '')}`;
   for (const href of links) {
     const url = new URL(href, `${origin}${pathname}`);
+    // Standalone docs CI has no Storybook artifact; the assembled Pages check validates it.
+    if (!env.DOCS_DIST && url.pathname.startsWith(`${base}storybook/`)) continue;
     if (url.origin !== origin) continue;
     if (!url.pathname.startsWith(base)) {
       failures.push(`${pathname}: outside base: ${href}`);

--- a/apps/docs/scripts/links.mjs
+++ b/apps/docs/scripts/links.mjs
@@ -9,6 +9,7 @@ export function normalizeBase(base = '/') {
 }
 
 export function rewriteUrl(url, source, entries, base = '/', storybook = '') {
+  if (url === 'examples:') return `${normalizeBase(base)}examples/`;
   if (url.startsWith('storybook:')) {
     if (!storybook) return `${normalizeBase(base)}docs/guides/storybook/`;
     const suffix = url.slice('storybook:'.length);

--- a/apps/docs/scripts/links.test.mjs
+++ b/apps/docs/scripts/links.test.mjs
@@ -69,3 +69,8 @@ test('Markdown, reference and raw HTML links rewrite without altering code examp
   assert.equal((code.match(/href="\/preview\/docs\/vue\/"/g) || []).length, 3);
   assert.match(code, /\[Vue\]\(\.\.\/packages\/vue\/README\.md\)/);
 });
+
+test('embedded examples keep the deployment base', () => {
+  assert.equal(rewriteUrl('examples:', 'docs/guide.md', entries, '/preview/'), '/preview/examples/');
+  assert.equal(rewriteUrl('examples:', 'docs/guide.md', entries, '/'), '/examples/');
+});

--- a/apps/docs/src/components/Header.astro
+++ b/apps/docs/src/components/Header.astro
@@ -13,7 +13,7 @@ const inDocs = Astro.url.pathname.startsWith(`${localizedBase}docs/`);
   <div class="brand"><SiteTitle /></div>
   <nav aria-label="Primary" class="primary-nav">
     <a href={`${localizedBase}docs/`} aria-current={inDocs ? 'location' : undefined}>{Astro.locals.t('nav.docs')}</a>
-    <a class="examples-link" href={`${localizedBase}docs/examples/`}>{Astro.locals.t('nav.examples')}</a>
+    <a class="examples-link" aria-current={Astro.url.pathname.startsWith(`${localizedBase}examples/`) ? 'page' : undefined} href={`${localizedBase}examples/`}>{Astro.locals.t('nav.examples')}</a>
     <a class="github-link" href="https://github.com/ai-markdown/ai-markdown">GitHub ↗</a>
   </nav>
   <div class="search"><Search /></div>
@@ -64,7 +64,7 @@ const inDocs = Astro.url.pathname.startsWith(`${localizedBase}docs/`);
     background-color: color-mix(in srgb, var(--sl-color-text) 6%, transparent);
   }
   @media (max-width: 65rem) {
-    .primary-nav .examples-link, .primary-nav .github-link { display: none; }
+    .primary-nav .github-link { display: none; }
     .site-header { gap: 1rem; }
   }
   @media (max-width: 49.99rem) {
@@ -74,7 +74,8 @@ const inDocs = Astro.url.pathname.startsWith(`${localizedBase}docs/`);
       grid-template-rows: 2.75rem 2.75rem;
       gap: 0.25rem 0.75rem;
     }
-    .primary-nav { justify-content: end; }
+    .primary-nav { justify-content: end; gap: 0.75rem; }
+    .brand :global(.brand-title span) { display: none; }
     .preferences { grid-row: 2; grid-column: 1 / -1; justify-content: end; }
   }
 </style>

--- a/apps/docs/src/components/SiteTitle.astro
+++ b/apps/docs/src/components/SiteTitle.astro
@@ -2,7 +2,7 @@
 const { siteTitleHref } = Astro.locals.starlightRoute;
 const base = import.meta.env.BASE_URL.replace(/\/?$/, '/');
 ---
-<a href={siteTitleHref} class="brand-title" translate="no">
+<a href={siteTitleHref} class="brand-title" aria-label="ai-markdown" translate="no">
   <img src={`${base}brand/organization-mark.png`} width="36" height="36" alt="" />
   <span>ai-markdown</span>
 </a>

--- a/apps/docs/src/pages/examples.astro
+++ b/apps/docs/src/pages/examples.astro
@@ -1,0 +1,50 @@
+---
+import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
+const base = import.meta.env.BASE_URL.replace(/\/?$/, '/');
+const catalog = (import.meta.env.DOCS_STORYBOOK_URL || `${base}storybook/`).replace(/\/?$/, '/');
+const entries = [
+  { label: 'All examples', url: `${catalog}?path=/story/react_playground--default` },
+  { label: 'React', url: `${catalog}react/?path=/story/playground--default` },
+  { label: 'Vue', url: `${catalog}vue/?path=/story/playground--interactive` },
+  { label: 'Mantine', url: `${catalog}react/?path=/docs/integrations-mantine-playground--docs` },
+];
+---
+<StarlightPage frontmatter={{ title: 'Examples', description: 'Explore live React, Vue and Mantine examples without leaving AI Markdown.', template: 'splash', editUrl: false, lastUpdated: false, pagination: false, pagefind: false }}>
+  <div class="examples-workspace">
+    <div class="examples-intro">
+      <p>Try Markdown, explore streaming, and adjust component options in the live catalog.</p>
+      <a id="open-catalog" href={entries[0].url} target="_blank" rel="noopener">Open in new tab ↗</a>
+    </div>
+    <nav class="catalog-tabs" aria-label="Example framework">
+      {entries.map((entry, index) => <a href={entry.url} data-catalog-url aria-current={index === 0 ? 'true' : undefined}>{entry.label}</a>)}
+    </nav>
+    <iframe id="examples-catalog" src={entries[0].url} title="Interactive AI Markdown Storybook examples" allow="clipboard-write; fullscreen"></iframe>
+  </div>
+</StarlightPage>
+<script>
+  const frame = document.querySelector<HTMLIFrameElement>('#examples-catalog');
+  const external = document.querySelector<HTMLAnchorElement>('#open-catalog');
+  document.querySelectorAll<HTMLAnchorElement>('[data-catalog-url]').forEach((link) => {
+    link.addEventListener('click', (event) => {
+      if (event.ctrlKey || event.metaKey || event.shiftKey || event.altKey || !frame || !external) return;
+      event.preventDefault();
+      frame.src = link.href;
+      external.href = link.href;
+      document.querySelectorAll('[data-catalog-url]').forEach((item) => item.removeAttribute('aria-current'));
+      link.setAttribute('aria-current', 'true');
+    });
+  });
+</script>
+<style>
+  .examples-workspace { width: 100%; }
+  .examples-intro { display: flex; align-items: center; justify-content: space-between; gap: 1rem; margin-bottom: 1.5rem; }
+  .examples-intro p { margin: 0; }
+  .examples-intro a { flex-shrink: 0; }
+  .catalog-tabs { display: flex; gap: 0.5rem; flex-wrap: wrap; margin-bottom: 1rem; }
+  .catalog-tabs a { padding: 0.5rem 1rem; border: 1px solid var(--sl-color-hairline); border-radius: 0.5rem; text-decoration: none; color: var(--sl-color-text); }
+  .catalog-tabs a[aria-current] { color: var(--sl-color-text-accent); background: var(--sl-color-accent-low); border-color: var(--sl-color-text-accent); }
+  iframe { display: block; width: 100%; height: calc(100dvh - var(--sl-nav-height) - 15rem); min-height: 36rem; border: 1px solid var(--sl-color-hairline); border-radius: 0.75rem; background: white; }
+  :global(body:has(.examples-workspace)) { --sl-content-width: 100%; }
+  :global(body:has(.examples-workspace) .main-pane) { width: 100%; }
+  @media (max-width: 50rem) { .examples-intro { align-items: start; flex-direction: column; } iframe { min-height: 38rem; } }
+</style>

--- a/docs/documentation-site.md
+++ b/docs/documentation-site.md
@@ -81,3 +81,9 @@ DOCS_DIST=_site pnpm test:docs
 ```
 
 `_site/` is ignored and contains the docs build at its root and the entire Storybook build in `storybook/`. The link check validates documentation links against this assembled directory, including same-origin links into the React and Vue catalogs. Pages receives one artifact only after both builds and their checks pass. Never deploy the docs and Storybook separately to the same Pages site: each deployment replaces the site's artifact.
+
+## Organization root website
+
+The public homepage is **`https://ai-markdown.github.io/`**. Its publishing repository is `ai-markdown/ai-markdown.github.io`, as required for GitHub organization sites. That repository calls this repository's reusable Pages workflow and checks out application source from `ai-markdown/ai-markdown`. It checks for source changes approximately every 15 minutes (scheduled runs may be delayed); manual dispatch publishes immediately. No cross-repository write credential is stored.
+
+The organization deployment uses `/` as its base: `/docs/` contains documentation, `/examples/` embeds the full Storybook UI with framework switches, and `/storybook/` remains available for direct links and standalone use. The existing project deployment under `/ai-markdown/` remains a working mirror. Both deployments derive their base from their own Pages settings.


### PR DESCRIPTION
Makes the website's Examples navigation open `/examples/`, retaining the shared header while embedding the complete Storybook UI. Framework links switch the embedded catalog between the combined hub, React, Vue, and Mantine, with an optional standalone tab. Mobile navigation keeps Examples accessible.

Makes the Pages workflow reusable by the organization website repository. The caller's Pages settings determine the URL prefix; application source is checked out from the main repository, preserving one source of truth. A published source marker lets the organization workflow skip unchanged scheduled builds.

Validation: Astro check, targeted ESLint, Prettier, seven link tests, 39-page assembled-site link checks at the project prefix, and Chromium desktop/mobile inspection of the embedded Storybook and Vue switching without leaving `/examples/`.
