### PR TITLE
Use 6px scrollbars on the documentation website

### DIFF
--- a/apps/docs/src/styles/custom.css
+++ b/apps/docs/src/styles/custom.css
@@ -48,3 +48,30 @@
     box-shadow: none;
   }
 }
+
+/* Firefox uses its native thin scrollbar; WebKit/Blink use an exact 6px size. */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--sl-color-gray-3) transparent;
+}
+@supports selector(::-webkit-scrollbar) {
+  * {
+    scrollbar-width: auto;
+    scrollbar-color: auto;
+  }
+  ::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  ::-webkit-scrollbar-track,
+  ::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+  ::-webkit-scrollbar-thumb {
+    background: var(--sl-color-gray-3);
+    border-radius: 3px;
+  }
+  ::-webkit-scrollbar-thumb:hover {
+    background: var(--sl-color-gray-2);
+  }
+}


### PR DESCRIPTION
Sets vertical and horizontal website scrollbars to 6px in browsers supporting scrollbar pseudo-elements, with theme-aware thumbs and Firefox thin-scrollbar fallback. Applies to the page, sidebar, and code blocks. Validation: Prettier and git diff checks.